### PR TITLE
Add default scopes

### DIFF
--- a/src/components/LinkedinLoginButton.js
+++ b/src/components/LinkedinLoginButton.js
@@ -105,6 +105,9 @@ class LinkedinLoginButton extends React.PureComponent {
     if (!clientId || !redirectUrl) {
       throw new Error('You must provide a client ID and a redirectUrl !')
     }
+    if (!Array.isArray(scopes)) {
+      throw new Error('You must provide an array on scope props')
+    }
     this.popup = window.open(
       `https://www.linkedin.com/oauth/v2/authorization?client_id=${clientId}&redirect_uri=${redirectUrl}&response_type=code&state=${this.stateKey}&scope=${scopes.join('+')}`,
       popupConfig.title || 'Login with linkedin',

--- a/src/components/LinkedinLoginButton.js
+++ b/src/components/LinkedinLoginButton.js
@@ -97,6 +97,7 @@ class LinkedinLoginButton extends React.PureComponent {
       redirectUrl,
       preventFromOpeningPopup,
       popupConfig,
+      scopes = ['r_liteprofile', 'r_emailaddress'],
     } = this.props
     if (typeof preventFromOpeningPopup === 'function' && preventFromOpeningPopup()) {
       return
@@ -105,7 +106,7 @@ class LinkedinLoginButton extends React.PureComponent {
       throw new Error('You must provide a client ID and a redirectUrl !')
     }
     this.popup = window.open(
-      `https://www.linkedin.com/oauth/v2/authorization?client_id=${clientId}&redirect_uri=${redirectUrl}&response_type=code&state=${this.stateKey}`,
+      `https://www.linkedin.com/oauth/v2/authorization?client_id=${clientId}&redirect_uri=${redirectUrl}&response_type=code&state=${this.stateKey}&scope=${scopes.join('+')}`,
       popupConfig.title || 'Login with linkedin',
       `height=${popupConfig.height || 600},width=${popupConfig.width || 500}`,
     )
@@ -148,6 +149,7 @@ LinkedinLoginButton.propTypes = {
     width: PropTypes.number,
     height: PropTypes.number,
   }),
+  scopes: PropTypes.arrayOf(PropTypes.string),
 }
 
 LinkedinLoginButton.defaultProps = {

--- a/src/components/LinkedinLoginButton.js
+++ b/src/components/LinkedinLoginButton.js
@@ -97,7 +97,7 @@ class LinkedinLoginButton extends React.PureComponent {
       redirectUrl,
       preventFromOpeningPopup,
       popupConfig,
-      scopes = ['r_liteprofile', 'r_emailaddress'],
+      scopes,
     } = this.props
     if (typeof preventFromOpeningPopup === 'function' && preventFromOpeningPopup()) {
       return
@@ -158,6 +158,7 @@ LinkedinLoginButton.defaultProps = {
     height: 600,
     title: 'Login with linkedin',
   },
+  scopes: ['r_liteprofile', 'r_emailaddress'],
 }
 
 export default LinkedinLoginButton


### PR DESCRIPTION
Due to new linkedin API update. We need to specify scopes to be compatible with old behavior (use bad default permission elsewhere)